### PR TITLE
Fix the build with GHC 7.10 and earlier

### DIFF
--- a/Text/Appar/Parser.hs
+++ b/Text/Appar/Parser.hs
@@ -72,15 +72,15 @@ instance Functor (MkParser inp) where
     f `fmap` p = return f <*> p
 
 instance Applicative (MkParser inp) where
-    pure  = return
-    (<*>) = ap
+    pure a = P $ \bs -> (Just a, bs)
+    (<*>)  = ap
 
 instance Alternative (MkParser inp) where
     empty = mzero
     (<|>) = mplus
 
 instance Monad (MkParser inp) where
-    return a = P $ \bs -> (Just a, bs)
+    return   = pure
     p >>= f  = P $ \bs -> case runParser p bs of
         (Nothing, bs') -> (Nothing, bs')
         (Just a,  bs') -> runParser (f a) bs'

--- a/appar.cabal
+++ b/appar.cabal
@@ -11,13 +11,17 @@ Cabal-Version:          >= 1.6
 Build-Type:             Simple
 Extra-Source-Files:     README
 library
-  GHC-Options:          -Wall -Wcompat -Wnoncanonical-monadfail-instances
+  GHC-Options:          -Wall
   Exposed-Modules:      Text.Appar.String
                         Text.Appar.ByteString
                         Text.Appar.LazyByteString
   Other-Modules:        Text.Appar.Input
                         Text.Appar.Parser
   Build-Depends:        base >= 4 && < 5, bytestring
+  if impl(ghc >= 8.0)
+    GHC-Options:        -Wcompat -Wnoncanonical-monad-instances -Wnoncanonical-monadfail-instances
+  else
+    Build-Depends:      fail == 4.9.*
 Source-Repository head
   Type:                 git
   Location:             git://github.com/kazu-yamamoto/appar.git


### PR DESCRIPTION
`appar-0.1.5` no longer builds with GHC 7.10 and earlier. Here is [an example of the breakge](https://travis-ci.org/scotty-web/scotty/jobs/465952802#L922) from `scotty`'s Travis CI build for GHC 7.10.3:

```
Failed to build appar-0.1.5.
Build log (
/home/travis/.cabal/logs/ghc-7.10.3/appar-0.1.5-30c77c4cd8dec4e2fe74da86534737f3b4a31a6e021426a653609375761a334c.log
):
Configuring appar-0.1.5...
Preprocessing library for appar-0.1.5..
Building library for appar-0.1.5..
ghc: unrecognised flag: -Wcompat
unrecognised flag: -Wnoncanonical-monadfail-instances
```

The culprit is the addition of this line in `appar.cabal`:

https://github.com/kazu-yamamoto/appar/blob/8005075f66d7e830cffdbcfff868ad6d566dbb11/appar.cabal#L14

As the `-Wcompat` and `-Wnoncanonical-monadfail-instances` flags are only supported with GHC 8.0 and later. This patch fixes the issue by wrapping these flags with `if impl(ghc >= 8.0)`, and depending on the `fail` compatibility package if using a version of GHC older than 8.0 (to ensure that `Control.Monad.Fail` is always available).