### PR TITLE
Require Cabal-Version 1.8

### DIFF
--- a/appar.cabal
+++ b/appar.cabal
@@ -7,7 +7,7 @@ License-File:           LICENSE
 Synopsis:               A simple applicative parser
 Description:            A simple applicative parser in Parsec style
 Category:               Parsing
-Cabal-Version:          >= 1.6
+Cabal-Version:          >= 1.8
 Build-Type:             Simple
 Extra-Source-Files:     README
 library


### PR DESCRIPTION
Hopefully this suppresses the following warning:

```
Warning: appar.cabal:20:37: version operators used. To use version operators
the package needs to specify at least 'cabal-version: >= 1.8'.
```